### PR TITLE
Better Embed!

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": true,
+  "singleQuote": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "semi": true,
-  "singleQuote": true
-}

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,14 +1,6 @@
 import { MessageEmbed } from 'discord.js';
-import getColor from './colors';
-import * as parser from './parser';
-
-function getLanguage(platform) {
-  if (platform === 'node') {
-    return 'javascript';
-  }
-
-  return platform;
-}
+import getColor from './colors.js';
+import * as parser from './parser.js';
 
 function cap(str, length) {
   if (str == null || str?.length <= length) {
@@ -28,43 +20,52 @@ export default function createMessage(event) {
   embed.setTimestamp(parser.getTime(event));
   embed.setColor(getColor(parser.getLevel(event)));
 
+  const fileLocation = parser.getFileLocation(event);
   embed.setDescription(
-    `\`\`\`${getLanguage(parser.getPlatform(event))}\n${cap(
-      parser.getErrorCodeSnippet(event),
-      4000
-    )}
+    `${fileLocation ? `\`📄 ${fileLocation}\`\n` : ''}\`\`\`${
+      parser.getLanguage(event) || parser.getPlatform(event)
+    }\n${cap(parser.getErrorCodeSnippet(event), 3900)}
     \`\`\``
   );
 
   const location = parser.getErrorLocation(event, 7);
-  embed.addField('Location', cap(location, 1024), true);
+  embed.addField('Stack', `\`\`\`${cap(location.join('\n'), 1000)}\n\`\`\``);
+
+  const tags = parser.getTags(event);
+  const release = parser.getRelease(event);
+  if (Object.keys(tags).length > 0 || release != null) {
+    embed.addField(
+      'Tags',
+      cap(
+        `${release ? `Release: ${release}\n` : ''}${tags
+          .map(([key, value]) => `${key}: ${value}`)
+          .join('\n')}`,
+        1024
+      ),
+      true
+    );
+  }
 
   const user = parser.getUser(event);
   if (user?.username) {
-    embed.addField('**User**', cap(user.username, 1024), true);
+    embed.addField(
+      'User',
+      cap(`${user.username} ${user.id ? `(${user.id})` : ''}`, 1024),
+      true
+    );
   }
 
   const contexts = parser.getContexts(event);
   if (contexts.length > 0) {
-    embed.addField('Contexts', cap(contexts.join('\n'), 1024));
-  }
+    embed.addField('Contexts', cap(contexts.join('\n'), 1024), true);
+  } /* else {
+    embed.addField("​", "​", true) // Zero-Width Space Field
+  }*/
 
   const extras = parser.getExtras(event);
   if (extras.length > 0) {
-    embed.addField('Extras', cap(extras.join('\n'), 1024));
+    embed.addField('Extras', cap(extras.join('\n'), 1024), true);
   }
-
-  const release = parser.getRelease(event);
-  if (release != null) {
-    embed.addField('Release', cap(release, 1024), true);
-  }
-
-  parser
-    .getTags(event)
-    ?.slice(0, 25 - embed.fields.length)
-    ?.forEach(([key, value]) =>
-      embed.addField(cap(key, 256), cap(value, 1024), true)
-    );
 
   return {
     username: 'Sentry',

--- a/lib/message.js
+++ b/lib/message.js
@@ -32,16 +32,10 @@ export default function createMessage(event) {
   embed.addField('Stack', `\`\`\`${cap(location.join('\n'), 1000)}\n\`\`\``);
 
   const tags = parser.getTags(event);
-  const release = parser.getRelease(event);
-  if (Object.keys(tags).length > 0 || release != null) {
+  if (Object.keys(tags).length > 0) {
     embed.addField(
       'Tags',
-      cap(
-        `${release ? `Release: ${release}\n` : ''}${tags
-          .map(([key, value]) => `${key}: ${value}`)
-          .join('\n')}`,
-        1024
-      ),
+      cap(tags.map(([key, value]) => `${key}: ${value}`).join('\n'), 1024),
       true
     );
   }
@@ -58,9 +52,12 @@ export default function createMessage(event) {
   const contexts = parser.getContexts(event);
   if (contexts.length > 0) {
     embed.addField('Contexts', cap(contexts.join('\n'), 1024), true);
-  } /* else {
-    embed.addField("​", "​", true) // Zero-Width Space Field
-  }*/
+  }
+
+  const release = parser.getRelease(event);
+  if (release) {
+    embed.addField('Release', `${release}`);
+  }
 
   const extras = parser.getExtras(event);
   if (extras.length > 0) {

--- a/lib/message.js
+++ b/lib/message.js
@@ -23,22 +23,13 @@ export default function createMessage(event) {
   const fileLocation = parser.getFileLocation(event);
   embed.setDescription(
     `${fileLocation ? `\`📄 ${fileLocation}\`\n` : ''}\`\`\`${
-      parser.getLanguage(event) || parser.getPlatform(event)
+      parser.getLanguage(event) ?? parser.getPlatform(event)
     }\n${cap(parser.getErrorCodeSnippet(event), 3900)}
     \`\`\``
   );
 
   const location = parser.getErrorLocation(event, 7);
   embed.addField('Stack', `\`\`\`${cap(location.join('\n'), 1000)}\n\`\`\``);
-
-  const tags = parser.getTags(event);
-  if (Object.keys(tags).length > 0) {
-    embed.addField(
-      'Tags',
-      cap(tags.map(([key, value]) => `${key}: ${value}`).join('\n'), 1024),
-      true
-    );
-  }
 
   const user = parser.getUser(event);
   if (user?.username) {
@@ -49,6 +40,20 @@ export default function createMessage(event) {
     );
   }
 
+  const tags = parser.getTags(event);
+  if (Object.keys(tags).length > 0) {
+    embed.addField(
+      'Tags',
+      cap(tags.map(([key, value]) => `${key}: ${value}`).join('\n'), 1024),
+      true
+    );
+  }
+
+  const extras = parser.getExtras(event);
+  if (extras.length > 0) {
+    embed.addField('Extras', cap(extras.join('\n'), 1024), true);
+  }
+
   const contexts = parser.getContexts(event);
   if (contexts.length > 0) {
     embed.addField('Contexts', cap(contexts.join('\n'), 1024), true);
@@ -56,12 +61,7 @@ export default function createMessage(event) {
 
   const release = parser.getRelease(event);
   if (release) {
-    embed.addField('Release', `${release}`);
-  }
-
-  const extras = parser.getExtras(event);
-  if (extras.length > 0) {
-    embed.addField('Extras', cap(extras.join('\n'), 1024), true);
+    embed.addField('Release', cap(release, 1024), true);
   }
 
   return {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -6,6 +6,10 @@ export function getPlatform(issue) {
   return getEvent(issue)?.platform;
 }
 
+export function getLanguage(issue) {
+  return getEvent(issue).location?.split('.').slice(-1)[0] || '';
+}
+
 export function getContexts(issue) {
   const contexts = getEvent(issue)?.contexts ?? {};
   const values = Object.values(contexts).map(
@@ -18,7 +22,7 @@ export function getContexts(issue) {
 export function getExtras(issue) {
   const extras = getEvent(issue)?.extra ?? {};
   const values = Object.entries(extras).map(
-    ([key, value]) => `${key} ${value}`
+    ([key, value]) => `${key}: ${value}`
   );
 
   return values ?? [];
@@ -56,6 +60,10 @@ export function getUser(issue) {
   return getEvent(issue)?.user;
 }
 
+export function getFileLocation(issue) {
+  return getEvent(issue)?.location;
+}
+
 export function getStacktrace(issue) {
   return (
     getEvent(issue)?.stacktrace ??
@@ -65,7 +73,7 @@ export function getStacktrace(issue) {
 
 export function getErrorLocation(issue, maxLines = Infinity) {
   const stacktrace = getStacktrace(issue);
-  const locations = stacktrace?.frames.reverse();
+  const locations = stacktrace?.frames; /*.reverse();*/
 
   let files = locations?.map(
     (location) =>
@@ -79,7 +87,7 @@ export function getErrorLocation(issue, maxLines = Infinity) {
     files.push('...');
   }
 
-  return files?.join('\n');
+  return files;
 }
 
 export function getErrorCodeSnippet(issue) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -7,7 +7,7 @@ export function getPlatform(issue) {
 }
 
 export function getLanguage(issue) {
-  return getEvent(issue).location?.split('.').slice(-1)[0] || '';
+  return getEvent(issue)?.location?.split('.')?.slice(-1)?.[0] || '';
 }
 
 export function getContexts(issue) {

--- a/pages/api/webhooks/[key].js
+++ b/pages/api/webhooks/[key].js
@@ -15,7 +15,7 @@ const handler = async (request, response) => {
 
   try {
     const { key } = request.query;
-    log.info(`Recieved event for ${key}`);
+    log.info(`Received event for ${key}`);
 
     prisma = new PrismaClient();
 


### PR DESCRIPTION
I've made some changes to the embed formatting which make it look a lot better, as well as fixed some issues.

New embed:
![](https://user-images.githubusercontent.com/28990589/127927794-208eb42e-fcbc-4351-a940-f4a9105cd8bd.png)

What I changed:
- The codeblock language is now parsed from the specific file that errored if exists, or the platform
- Combined tags into one field instead of creating a new field every time
- Fixed extras formatting, and added the version to the top of the extras field
- Added the user id to the user option if it exists
- I decreased the character for cap cutoffs on codeblocks, as the codeblock takes up some of the character limit
- Made the stack trace a code block
- Fixed a typo
- Ran my changes through prettier!

My changes should completely support everything that was in the embed before, though it probably should still be tested.