### PR TITLE
feat: Update to use "new" Integrations

### DIFF
--- a/lib/legacyParser.ts
+++ b/lib/legacyParser.ts
@@ -1,11 +1,11 @@
 type SentryIssue = Record<string, any>;
 
 export function getEvent(issue: SentryIssue) {
-  return issue?.event ?? issue?.data?.issue ?? issue?.data?.event ?? issue;
+  return issue?.event ?? issue?.data?.issue ?? issue;
 }
 
 export function getProject(issue: SentryIssue) {
-  return issue?.project?.project_name ?? getEvent(issue)?.project?.name;
+  return issue?.project?.project_name ?? getEvent(issue)?.project?.name ?? issue.project_name;
 }
 
 export function getPlatform(issue: SentryIssue) {
@@ -128,5 +128,5 @@ export function getErrorCodeSnippet(issue: SentryIssue) {
 }
 
 export function getMessage(issue: SentryIssue) {
-  return issue?.message ?? getEvent(issue)?.message;
+  return issue?.message;
 }

--- a/lib/message.ts
+++ b/lib/message.ts
@@ -1,5 +1,6 @@
 import { APIEmbedField, EmbedBuilder } from "discord.js";
 import getColor from "./colors";
+import * as legacyParser from "./legacyParser";
 import * as parser from "./parser";
 
 function cap(str: string, length: number) {
@@ -10,11 +11,35 @@ function cap(str: string, length: number) {
 	return str.substr(0, length - 1) + "\u2026";
 }
 
-export default function createMessage(event) {
+export function createMessage(event) {
+    console.debug("Received new event");
+
+    console.debug({
+        event: parser.getEvent(event),
+        project: parser.getProject(event),
+        platform: parser.getPlatform(event),
+        language: parser.getLanguage(event),
+        contexts: parser.getContexts(event),
+        extras: parser.getExtras(event),
+        link: parser.getLink(event),
+        tags: parser.getTags(event),
+        level: parser.getLevel(event),
+        type: parser.getType(event),
+        title: parser.getTitle(event),
+        time: parser.getTime(event),
+        user: parser.getUser(event),
+        release: parser.getRelease(event),
+        fileLocation: parser.getFileLocation(event),
+        stackTrace: parser.getStacktrace(event),
+        errorLocation: parser.getErrorLocation(event, 7),
+        errorCodeSnippet: parser.getErrorCodeSnippet(event),
+        message: parser.getMessage(event),
+    });
+
 	const embed = new EmbedBuilder()
 		.setColor(getColor(parser.getLevel(event)))
 		.setAuthor({
-			name: event.project_name,
+			name: event.data.triggered_rule,
 			iconURL: "https://sentrydiscord.dev/icons/sentry.png",
 		})
 		.setFooter({
@@ -103,6 +128,134 @@ export default function createMessage(event) {
 	}
 
 	const release = parser.getRelease(event);
+	if (release) {
+		fields.push({ name: "Release", value: cap(release, 1024), inline: true });
+	}
+
+	embed.addFields(fields);
+	return {
+		username: "Sentry",
+		avatar_url: `https://sentrydiscord.dev/icons/sentry.png`,
+		embeds: [embed.toJSON()],
+	};
+}
+
+export function createLegacyMessage(event) {
+    console.debug("Received legacy event");
+
+    console.debug({
+        event: legacyParser.getEvent(event),
+        project: legacyParser.getProject(event),
+        platform: legacyParser.getPlatform(event),
+        language: legacyParser.getLanguage(event),
+        contexts: legacyParser.getContexts(event),
+        extras: legacyParser.getExtras(event),
+        link: legacyParser.getLink(event),
+        tags: legacyParser.getTags(event),
+        level: legacyParser.getLevel(event),
+        type: legacyParser.getType(event),
+        title: legacyParser.getTitle(event),
+        time: legacyParser.getTime(event),
+        user: legacyParser.getUser(event),
+        release: legacyParser.getRelease(event),
+        fileLocation: legacyParser.getFileLocation(event),
+        stackTrace: legacyParser.getStacktrace(event),
+        errorLocation: legacyParser.getErrorLocation(event, 7),
+        errorCodeSnippet: legacyParser.getErrorCodeSnippet(event),
+        message: legacyParser.getMessage(event),
+    });
+	const embed = new EmbedBuilder()
+		.setColor(getColor(legacyParser.getLevel(event)))
+		.setAuthor({
+			name: event.project_name,
+			iconURL: "https://sentrydiscord.dev/icons/sentry.png",
+		})
+		.setFooter({
+			text: "Please consider sponsoring us!",
+			iconURL: "https://sentrydiscord.dev/sponsor.png",
+		})
+		.setTimestamp(legacyParser.getTime(event));
+
+	const projectName = legacyParser.getProject(event);
+
+	const eventTitle = legacyParser.getTitle(event);
+
+	if (projectName) {
+		const embedTitle = `[${projectName}] ${eventTitle}`;
+		embed.setTitle(cap(embedTitle, 250));
+	} else {
+		embed.setTitle(cap(eventTitle, 250));
+	}
+
+	const link = legacyParser.getLink(event);
+	if (link.startsWith("https://") || link.startsWith("http://")) {
+		embed.setURL(legacyParser.getLink(event));
+	}
+
+	const fileLocation = legacyParser.getFileLocation(event);
+	const snippet = cap(legacyParser.getErrorCodeSnippet(event), 3900);
+
+	if (snippet) {
+		embed.setDescription(
+			`${fileLocation ? `\`📄 ${fileLocation.slice(-95)}\`\n` : ""}\`\`\`${
+				legacyParser.getLanguage(event) ?? legacyParser.getPlatform(event)
+			}\n${snippet}
+      \`\`\``
+		);
+	} else {
+		embed.setDescription("Unable to generate code snippet.");
+	}
+
+	const fields: APIEmbedField[] = [];
+
+	const location = legacyParser.getErrorLocation(event, 7);
+	if (location?.length > 0) {
+		fields.push({
+			name: "Stack",
+			value: `\`\`\`${cap(location.join("\n"), 1000)}\n\`\`\``,
+		});
+	}
+
+	const user = legacyParser.getUser(event);
+	if (user?.username) {
+		fields.push({
+			name: "User",
+			value: cap(`${user.username} ${user.id ? `(${user.id})` : ""}`, 1024),
+			inline: true,
+		});
+	}
+
+	const tags = legacyParser.getTags(event);
+	if (Object.keys(tags).length > 0) {
+		fields.push({
+			name: "Tags",
+			value: cap(
+				tags.map(([key, value]) => `${key}: ${value}`).join("\n"),
+				1024
+			),
+			inline: true,
+		});
+	}
+
+	const extras = legacyParser.getExtras(event);
+	if (extras.length > 0) {
+		fields.push({
+			name: "Extras",
+			value: cap(extras.join("\n"), 1024),
+			inline: true,
+		});
+	}
+
+	const contexts = legacyParser.getContexts(event);
+	if (contexts.length > 0) {
+		fields.push({
+			name: "Contexts",
+			value: cap(contexts.join("\n"), 1024),
+			inline: true,
+		});
+	}
+
+	const release = legacyParser.getRelease(event);
 	if (release) {
 		fields.push({ name: "Release", value: cap(release, 1024), inline: true });
 	}

--- a/lib/message.ts
+++ b/lib/message.ts
@@ -19,7 +19,7 @@ export function createMessage(requestBody) {
 	const embed = new EmbedBuilder()
 		.setColor(getColor(eventLevel))
 		.setAuthor({
-			name: requestBody.triggered_rule ?? "Sentry Event",
+			name: requestBody?.data?.triggered_rule ?? "Sentry Event",
 			iconURL: "https://sentrydiscord.dev/icons/sentry.png",
 		})
 		.setFooter({

--- a/lib/message.ts
+++ b/lib/message.ts
@@ -12,30 +12,7 @@ function cap(str: string, length: number) {
 }
 
 export function createMessage(requestBody) {
-    console.debug("Received new event");
-
     const event = parser.getEvent(requestBody);
-
-    console.debug({
-        event: parser.getEvent(event),
-        platform: parser.getPlatform(event),
-        language: parser.getLanguage(event),
-        contexts: parser.getContexts(event),
-        extras: parser.getExtras(event),
-        link: parser.getLink(event),
-        tags: parser.getTags(event),
-        level: parser.getLevel(event),
-        type: parser.getType(event),
-        title: parser.getTitle(event),
-        time: parser.getTime(event),
-        user: parser.getUser(event),
-        release: parser.getRelease(event),
-        fileLocation: parser.getFileLocation(event),
-        stackTrace: parser.getStacktrace(event),
-        errorLocation: parser.getErrorLocation(event, 7),
-        errorCodeSnippet: parser.getErrorCodeSnippet(event),
-        message: parser.getMessage(event),
-    });
 
     const eventLevel = parser.getLevel(event);
 
@@ -137,29 +114,6 @@ export function createMessage(requestBody) {
 }
 
 export function createLegacyMessage(event) {
-    console.debug("Received legacy event");
-
-    console.debug({
-        event: legacyParser.getEvent(event),
-        project: legacyParser.getProject(event),
-        platform: legacyParser.getPlatform(event),
-        language: legacyParser.getLanguage(event),
-        contexts: legacyParser.getContexts(event),
-        extras: legacyParser.getExtras(event),
-        link: legacyParser.getLink(event),
-        tags: legacyParser.getTags(event),
-        level: legacyParser.getLevel(event),
-        type: legacyParser.getType(event),
-        title: legacyParser.getTitle(event),
-        time: legacyParser.getTime(event),
-        user: legacyParser.getUser(event),
-        release: legacyParser.getRelease(event),
-        fileLocation: legacyParser.getFileLocation(event),
-        stackTrace: legacyParser.getStacktrace(event),
-        errorLocation: legacyParser.getErrorLocation(event, 7),
-        errorCodeSnippet: legacyParser.getErrorCodeSnippet(event),
-        message: legacyParser.getMessage(event),
-    });
 	const embed = new EmbedBuilder()
 		.setColor(getColor(legacyParser.getLevel(event)))
 		.setAuthor({

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -1,33 +1,120 @@
 type SentryIssue = Record<string, any>;
 
-export function getEvent(issue: SentryIssue) {
-  return issue?.event ?? issue?.data?.issue ?? issue?.data?.event ?? issue;
+type SentryEvent = {
+    event_id: string;
+    project: string;
+    release?: string;
+    dist?: string,
+    platform?: string;
+    message?: string,
+    datetime?: string;
+    tags?: Record<string, string>;
+    _metrics?: Record<string, number>;
+    _ref?: number;
+    _ref_version?: number;
+    contexts?: Record<string, any>;
+    culprit?: string;
+    environment?: string;
+    extra?: Record<string, any>;
+    fingerprint?: Array<string>;
+    grouping_config?: Record<string, any>;
+    hashes?: Array<string>;
+    level?: string;
+    location?: string;
+    logentry?: {
+        formatted?: string;
+        message?: string;
+        params?: Array<string>;
+    };
+    logger?: string;
+    metadata?: Record<string, any>;
+    modules?: Record<string, string>;
+    nodestore_insert?: number;
+    received?: number;
+    request?: {
+        url?: string;
+        method?: string;
+        headers?: Record<string, string>;
+        data?: string;
+        env?: Record<string, string>;
+        inferred_content_type?: string;
+        api_target?: string;
+        cookies?: Record<string, string>;
+    };
+    stacktrace?: {
+        frames?: Array<{
+            function?: string,
+            module?: string,
+            filename?: string,
+            abs_path?: string,
+            lineno?: number,
+            pre_context?: Array<string>,
+            context_line?: string,
+            post_context?: Array<string>,
+            in_app?: boolean,
+            vars?: Record<string, any>,
+            colno?: number,
+            data?: Record<string, any>,
+            errors?: Array<string>,
+            raw_function?: string,
+            image_addr?: string,
+            instruction_addr?: string,
+            addr_mode?: string,
+            package?: string,
+            platform?: string,
+            source_link?: string,
+            symbol?: string,
+            symbol_addr?: string,
+            trust?: boolean,
+            lock?: boolean,
+        }>;
+    };
+    timestamp?: number;
+    title?: string;
+    type?: string;
+    user?: {
+        id?: string;
+        email?: string;
+        ip_address?: string;
+        username?: string;
+        name?: string;
+        geo?: {
+            country_code?: string;
+            region?: string;
+            city?: string;
+        };
+    };
+    version?: string;
+    url?: string;
+    web_url?: string;
+    issue_url?: string;
+    issue_id?: string;
+};
+
+
+export function getEvent(issue: SentryIssue): SentryEvent {
+  return issue?.data?.event ?? issue;
 }
 
-export function getProject(issue: SentryIssue) {
-  return issue?.project?.project_name ?? getEvent(issue)?.project?.name;
+export function getPlatform(event: SentryEvent) {
+    return event?.platform || "unknown";
 }
 
-export function getPlatform(issue: SentryIssue) {
-  return getEvent(issue)?.platform;
+export function getLanguage(event: SentryEvent) {
+    return event?.location?.split(".")?.slice(-1)?.[0] || "";
 }
 
-export function getLanguage(issue: SentryIssue) {
-  return getEvent(issue)?.location?.split(".")?.slice(-1)?.[0] || "";
-}
-
-export function getContexts(issue: SentryIssue) {
-  const contexts = getEvent(issue)?.contexts ?? {};
-  const values = Object.values(contexts)
-    .map((value: Record<string, unknown>) => `${value?.name} ${value?.version}`)
-    // TODO: Have a better decision tree here
-    .filter((value) => value !== "undefined undefined");
+export function getContexts(event: SentryEvent) {
+    const contexts = getEvent(event)?.contexts ?? {};
+    const values = Object.values(contexts)
+        .map((value: Record<string, unknown>) => `${value?.name} ${value?.version}`)
+        .filter((value) => value !== "undefined undefined");
 
   return values ?? [];
 }
 
-export function getExtras(issue: SentryIssue) {
-  const extras = getEvent(issue)?.extra ?? {};
+export function getExtras(event: SentryEvent) {
+  const extras = event?.extra ?? {};
   const values = Object.entries(extras).map(
     ([key, value]) => `${key}: ${value}`
   );
@@ -35,65 +122,56 @@ export function getExtras(issue: SentryIssue) {
   return values ?? [];
 }
 
-export function getLink(issue: SentryIssue) {
-  return issue?.url ?? "https://sentry.io";
+export function getLink(event: SentryEvent) {
+    return event?.url ?? "https://sentry.io";
 }
 
-export function getTags(issue: SentryIssue) {
-  return getEvent(issue)?.tags ?? [];
+export function getTags(event: SentryEvent) {
+  return event?.tags ?? [];
 }
 
-export function getLevel(issue: SentryIssue) {
-  return getEvent(issue)?.level;
+export function getLevel(event: SentryEvent) {
+  return event?.level;
 }
 
-export function getType(issue: SentryIssue) {
-  return getEvent(issue)?.type;
+export function getType(event: SentryEvent) {
+  return event?.type;
 }
 
-export function getTitle(issue: SentryIssue) {
-  return getEvent(issue)?.title ?? "Sentry Event";
+export function getTitle(event: SentryEvent) {
+  return event?.title ?? "Sentry Event";
 }
 
-export function getTime(issue: SentryIssue) {
-  const event = getEvent(issue);
-
+export function getTime(event: SentryEvent) {
   if (event?.timestamp) {
-    return new Date(getEvent(issue)?.timestamp * 1000);
-  }
-
-  if (event?.lastSeen != null) {
-    return new Date(event?.lastSeen);
-  }
-
-  if (event?.firstSeen != null) {
-    return new Date(event?.firstSeen);
+    return new Date(event?.timestamp * 1000);
   }
 
   return new Date();
 }
 
-export function getRelease(issue: SentryIssue) {
-  return getEvent(issue)?.release;
+export function getRelease(event: SentryEvent) {
+  return event?.release;
 }
 
-export function getUser(issue: SentryIssue) {
-  return getEvent(issue)?.user;
+export function getUser(event: SentryEvent) {
+  return event?.user;
 }
 
-export function getFileLocation(issue: SentryIssue) {
-  return getEvent(issue)?.location;
+export function getFileLocation(event: SentryEvent) {
+  return event?.location;
 }
 
-export function getStacktrace(issue: SentryIssue) {
+export function getStacktrace(event: SentryEvent) {
   return (
-    getEvent(issue)?.stacktrace ??
-    getEvent(issue)?.exception?.values[0]?.stacktrace
+    event?.stacktrace || {
+        frames: [],
+    }
   );
 }
 
-export function getErrorLocation(issue: SentryIssue, maxLines = Infinity) {
-  const stacktrace = getStacktrace(issue);
+export function getErrorLocation(event: SentryEvent, maxLines = Infinity) {
+  const stacktrace = getStacktrace(event);
   const locations = stacktrace?.frames; /*.reverse();*/
 
   let files = locations?.map(
@@ -111,22 +189,26 @@ export function getErrorLocation(issue: SentryIssue, maxLines = Infinity) {
   return files;
 }
 
-export function getErrorCodeSnippet(issue: SentryIssue) {
-  const stacktrace = getStacktrace(issue);
+export function getErrorCodeSnippet(event: SentryEvent) {
+  const stacktrace = getStacktrace(event);
   const location = stacktrace?.frames?.reverse()?.[0];
 
   if (!location) {
-    const event = getEvent(issue);
     return event?.culprit ?? null;
   }
 
-  // The spaces below are intentional - they help align the code
-  // aorund the additional `>` marker
+  const startingLine = location.lineno - (location.pre_context?.length ?? 0);
+  
   return ` ${location.pre_context?.join("\n ") ?? ""}\n>${
     location.context_line
-  }\n${location.post_context?.join("\n") ?? ""}`;
+  }\n ${location.post_context?.join("\n ") ?? ""}`;
+
+ // TODO: Consider adding line numbers to the code snippet
+  return ` ${location.pre_context?.map((line, index) => `${startingLine - location.pre_context?.length ?? 0 + index} | ${line}`).join("\n ") ?? ""}\n>${location.lineno}>| ${
+      location.context_line
+    }\n${location.post_context?.map((line, index) => `${index + location.lineno + 1} | ${line}`).join("\n ") ?? ""}`;
 }
 
-export function getMessage(issue: SentryIssue) {
-  return issue?.message ?? getEvent(issue)?.message;
+export function getMessage(event: SentryEvent) {
+  return event?.message;
 }

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -8,7 +8,7 @@ type SentryEvent = {
     platform?: string;
     message?: string,
     datetime?: string;
-    tags?: Record<string, string>;
+    tags?: Array<[string, string]>;
     _metrics?: Record<string, number>;
     _ref?: number;
     _ref_version?: number;

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -196,17 +196,10 @@ export function getErrorCodeSnippet(event: SentryEvent) {
   if (!location) {
     return event?.culprit ?? null;
   }
-
-  const startingLine = location.lineno - (location.pre_context?.length ?? 0);
   
   return ` ${location.pre_context?.join("\n ") ?? ""}\n>${
     location.context_line
   }\n ${location.post_context?.join("\n ") ?? ""}`;
-
- // TODO: Consider adding line numbers to the code snippet
-  return ` ${location.pre_context?.map((line, index) => `${startingLine - location.pre_context?.length ?? 0 + index} | ${line}`).join("\n ") ?? ""}\n>${location.lineno}>| ${
-      location.context_line
-    }\n${location.post_context?.map((line, index) => `${index + location.lineno + 1} | ${line}`).join("\n ") ?? ""}`;
 }
 
 export function getMessage(event: SentryEvent) {

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -123,7 +123,7 @@ export function getExtras(event: SentryEvent) {
 }
 
 export function getLink(event: SentryEvent) {
-    return event?.url ?? "https://sentry.io";
+    return event?.web_url ?? event?.url ?? "https://sentry.io";
 }
 
 export function getTags(event: SentryEvent) {

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -1,5 +1,22 @@
 type SentryIssue = Record<string, any>;
 
+type SentryStacktrace = {
+    frames?: Array<{
+        function?: string;
+        module?: string;
+        filename?: string;
+        abs_path?: string;
+        lineno?: number;
+        pre_context?: Array<string>;
+        context_line?: string;
+        post_context?: Array<string>;
+        in_app?: boolean;
+        vars?: Record<string, any>;
+        colno?: number;
+        data?: Record<string, any>;
+    }>;
+};
+
 type SentryEvent = {
     event_id: string;
     project: string;
@@ -41,34 +58,7 @@ type SentryEvent = {
         api_target?: string;
         cookies?: Record<string, string>;
     };
-    stacktrace?: {
-        frames?: Array<{
-            function?: string,
-            module?: string,
-            filename?: string,
-            abs_path?: string,
-            lineno?: number,
-            pre_context?: Array<string>,
-            context_line?: string,
-            post_context?: Array<string>,
-            in_app?: boolean,
-            vars?: Record<string, any>,
-            colno?: number,
-            data?: Record<string, any>,
-            errors?: Array<string>,
-            raw_function?: string,
-            image_addr?: string,
-            instruction_addr?: string,
-            addr_mode?: string,
-            package?: string,
-            platform?: string,
-            source_link?: string,
-            symbol?: string,
-            symbol_addr?: string,
-            trust?: boolean,
-            lock?: boolean,
-        }>;
-    };
+    stacktrace?: SentryStacktrace;
     timestamp?: number;
     title?: string;
     type?: string;
@@ -89,6 +79,19 @@ type SentryEvent = {
     web_url?: string;
     issue_url?: string;
     issue_id?: string;
+    exception?: {
+        values: Array<{
+            type?: string;
+            value?: string;
+            module?: string;
+            mechanism?: {
+                type?: string;
+                handled?: boolean;
+                data?: Record<string, any>;
+            };
+            stacktrace?: SentryStacktrace;
+        }>;
+    }
 };
 
 
@@ -164,7 +167,7 @@ export function getFileLocation(event: SentryEvent) {
 
 export function getStacktrace(event: SentryEvent) {
   return (
-    event?.stacktrace || {
+    event?.stacktrace || event?.exception?.values?.[0]?.stacktrace || {
         frames: [],
     }
   );

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -212,15 +212,24 @@ export default function Create() {
               <h2 className="text-center text-3xl leading-8 font-extrabold tracking-tight text-gray-900 sm:text-4xl">
                 Finally, add the Webhook Integration to Sentry
               </h2>
-              <p className="mt-4 max-w-3xl mx-auto text-center text-xl text-gray-500">
-                You can find it under <strong>Settings</strong> &rarr;{' '}
-                <strong>Integrations</strong> &rarr; <strong>Webhooks</strong>.
-                Add it to your project, and then in the{' '}
-                <strong>Configure</strong> screen add the above link to the{' '}
-                <strong>Callback URLs</strong>. That's it! Save your changes,
-                and click "Test plugin" to see it in action.
+              <ul className="mt-4 max-w-3xl mx-auto text-xl text-gray-500 space-y-2">
+                <li>
+                  Create a new integration by going to <strong>Settings</strong> &rarr; <strong>Custom Integrations</strong> &rarr; <strong>Create New Integration</strong>, and selecting <strong>Internal Integration</strong>.
+                </li>
+                <li>
+                  Paste the above link into the <strong>Webhook URL</strong> field and enable <strong>Alert Rule Action</strong>.
+                </li>
+                <li>
+                  Go to <strong>Alerts</strong> &rarr; <strong>Create Alert</strong> and set up a new rule to <strong>Send a notification via an integration</strong>, and choose the integration you just created.
+                </li>
+              </ul>
+              <p className="mt-4 max-w-lg mx-auto text-center text-xl text-gray-500">
+                Confused? Check out the demo below for a walkthrough!
               </p>
-              <p className="mt-4 max-w-3xl mx-auto text-center text-xl text-gray-500">
+              <div className="mt-8 relative h-0 w-full pb-[480px]">
+                <iframe loading="lazy" allowFullScreen={true} allow="fullscreen;" className="absolute w-full h-full top-0 left-0" src="https://demo.arcade.software/v7uhzmdV6Q5PDzoVPAE6?embed" />
+              </div>
+              <p className="mt-8 max-w-3xl mx-auto text-center text-xl text-gray-500">
                 If you would like to target a specific thread on Discord, you
                 can add <strong>?thread_id=123</strong> to the URL you paste
                 into Sentry (replacing 123 with the thread ID).

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -266,13 +266,11 @@ export default function Home({ events, webhooks }) {
 										</p>
 									</Question>
 
-									<Question title="Want a native integration?">
-										Me too! There's an{" "}
-										<QuestionExternalLink href="https://github.com/getsentry/sentry/issues/10925">
-											open issue on GitHub
-										</QuestionExternalLink>{" "}
-										that you can go and leave reactions on to help get it
-										prioritized. If official support lands, this service will
+									<Question title="What about the native integration?">
+                                        Unfortunately, the native Sentry integration for Discord is
+                                        only available for paid Sentry plans. This service provides
+                                        a free alternative for everyone! If the native integration
+                                        ever becomes available for free plans, this service will
 										likely stop allowing new registrations but will remain up so
 										long as webhooks are receiving events.
 									</Question>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -103,21 +103,6 @@ export default function Home({ events, webhooks }) {
 						</div>
 					</div>
 
-					<div className="rounded-md bg-red-50 p-4 max-w-4xl mx-auto mb-8">
-						<div className="flex">
-							<div className="flex-shrink-0">
-								<svg
-									xmlns="http://www.w3.org/2000/svg"
-									className="h-5 w-5 text-red-400"
-									aria-hidden="true"
-									viewBox="0 0 16 16"
-								>
-									<path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5m.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2" />
-								</svg>
-							</div>
-						</div>
-					</div>
-
 					<DonationBanner />
 
 					<div className="max-w-xl mx-auto px-4 sm:px-6 lg:px-8 lg:max-w-7xl">


### PR DESCRIPTION
Sentry no longer allows for the creation of (now legacy) webhooks. *Or rather... it does, but it's incredibly hidden and convoluted.*

This PR:
- Updates the API to use the "new" Sentry Integrations, while maintaining support for legacy webhooks
- Updates /create to explain how to use the "new" Sentry Integrations, I also included the same demo from [the Sentry Docs](https://docs.sentry.io/organization/integrations/integration-platform/webhooks/issue-alerts/#payload). I'm not sure whether this is (legally?) okay, but I feel it does make it a lot easier to understand.
- Fixes #48 and potential similar issues/confusion
- Removes the "Data Loss Notification" warning SVG added in e2c5c7ec096263e6a15cbe0a6b5b26b3b3f3af33, that was not removed when the text was removed in 2a460fb6f7dec8cfbe5c0735b9da89776df7d50d
- Updates the native integration "Common Question" to address its existence for paid plans only